### PR TITLE
123 rx form emit

### DIFF
--- a/packages/forms/src/RxForm/Tests/combinedTest.test.ts
+++ b/packages/forms/src/RxForm/Tests/combinedTest.test.ts
@@ -1,0 +1,73 @@
+import { build } from '../RxForm';
+import { RxBuilder, combine } from '@reactables/core';
+import { Subscription } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { config } from '../../Testing/config';
+
+const RxCombined = () => {
+  const rxToggle = RxBuilder({
+    initialState: false,
+    reducers: {
+      toggle: (state) => !state,
+    },
+  });
+
+  const rxForm = build(config.controls.firstName);
+
+  return combine({
+    toggle: rxToggle,
+    form: rxForm,
+  });
+};
+
+describe('RxForm', () => {
+  let testScheduler: TestScheduler;
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toMatchObject(expected);
+    });
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+  });
+
+  describe('using build and combined with other Reactables', () => {
+    it('should emit initial state', () => {
+      testScheduler.run(({ expectObservable, cold }) => {
+        const [state$, actions] = RxCombined();
+
+        subscription = cold('-b', { b: actions.toggle.toggle }).subscribe((action) => action());
+
+        expectObservable(state$).toBe('ab', {
+          a: {
+            toggle: false,
+            form: {
+              root: {
+                value: '',
+                pristineValue: '',
+                config: config.controls.firstName,
+                touched: false,
+                validatorErrors: { required: true },
+              },
+            },
+          },
+          b: {
+            toggle: true,
+            form: {
+              root: {
+                value: '',
+                pristineValue: '',
+                config: config.controls.firstName,
+                touched: false,
+                validatorErrors: { required: true },
+              },
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/packages/react/src/Hooks/useReactable.ts
+++ b/packages/react/src/Hooks/useReactable.ts
@@ -10,7 +10,7 @@ export const useReactable = <T, S, U extends unknown[]>(
 ): HookedReactable<T, S> => {
   const rx = useRef<Reactable<T, S>>(null);
 
-  if (rx === null) {
+  if (rx.current === null) {
     rx.current = reactableFactory(...props);
   }
 

--- a/packages/react/src/Hooks/useReactable.ts
+++ b/packages/react/src/Hooks/useReactable.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Reactable, Action } from '@reactables/core';
 
 export type HookedReactable<T, S> = [T, S, Observable<T>, Observable<Action<unknown>>?];
@@ -8,7 +8,13 @@ export const useReactable = <T, S, U extends unknown[]>(
   reactableFactory: (...props: U) => Reactable<T, S>,
   ...props: U
 ): HookedReactable<T, S> => {
-  const [state$, actions, messages$] = useMemo(() => reactableFactory(...props), []);
+  const rx = useRef<Reactable<T, S>>(null);
+
+  if (rx === null) {
+    rx.current = reactableFactory(...props);
+  }
+
+  const [state$, actions, actions$] = rx.current;
   const [state, setState] = useState<T>();
 
   useEffect(() => {
@@ -16,16 +22,8 @@ export const useReactable = <T, S, U extends unknown[]>(
       setState(result);
     });
 
-    return () => {
-      // Adding setTimeout fixes the issue.
-      // React Strict Mode has bugs with clean up with refs so it breaks the useReactable hook as of now
-      // See Bug: https://github.com/facebook/react/issues/26315
-      // See Bug: https://github.com/facebook/react/issues/24670
-      setTimeout(() => {
-        subscription.unsubscribe();
-      }, 0);
-    };
+    return () => subscription.unsubscribe();
   }, [state$]);
 
-  return [state, actions, state$, messages$];
+  return [state, actions, state$, actions$];
 };

--- a/packages/react/src/Hooks/useReactable.ts
+++ b/packages/react/src/Hooks/useReactable.ts
@@ -10,6 +10,12 @@ export const useReactable = <T, S, U extends unknown[]>(
 ): HookedReactable<T, S> => {
   const rx = useRef<Reactable<T, S>>(null);
 
+  /**
+   * React Strict Mode has bugs with clean up with refs so it breaks the useReactable hook as of now
+   * See Bug: https://github.com/facebook/react/issues/26315
+   * See Bug: https://github.com/facebook/react/issues/24670
+   * Using this recommended approach for resolving Strict Modeissue: https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents
+   */
   if (rx.current === null) {
     rx.current = reactableFactory(...props);
   }


### PR DESCRIPTION
# Description

Turns out the bug is more related to React Strict Mode.

In `useReactable` removed `useMemo` and used `useRef` instead and implementing recommended practices below.

Add a fix here to properly create refs for the Reactable as per https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
