### PR TITLE
128 store value reactable

### DIFF
--- a/packages/core/src/Factories/HubFactory.ts
+++ b/packages/core/src/Factories/HubFactory.ts
@@ -58,7 +58,7 @@ export const HubFactory = ({ effects, sources = [] }: HubConfig = {}): Hub => {
 
   const messages$ = merge(inputStream$, mergedScopedEffects, ...genericEffects).pipe(share());
 
-  const store = <T>({ reducer, name, debug, initialState, storeValue = false }: StoreConfig<T>) => {
+  const store = <T>({ reducer, name, debug, initialState }: StoreConfig<T>) => {
     const debugName = `[RX NAME] ${name || 'undefined'}\n`;
 
     const seedState = initialState !== undefined ? initialState : reducer();
@@ -116,14 +116,6 @@ export const HubFactory = ({ effects, sources = [] }: HubConfig = {}): Hub => {
       }),
       map((pair) => pair[1] as T),
     );
-
-    if (storeValue) {
-      const replaySubject = new ReplaySubject<T>(1);
-
-      state$.subscribe((state) => replaySubject.next(state));
-
-      return replaySubject;
-    }
 
     return state$;
   };

--- a/packages/core/src/Helpers/RxBuilder.ts
+++ b/packages/core/src/Helpers/RxBuilder.ts
@@ -5,6 +5,7 @@ import { HubFactory } from '../Factories/HubFactory';
 import { Reactable } from '../Models/Reactable';
 import { Effect } from '../Models/Effect';
 import { Action, ScopedEffects } from '../Models/Action';
+import { storeValue, DestroyAction } from './storeValue';
 
 export interface EffectsAndSources {
   effects?: Effect<unknown, unknown>[];
@@ -21,7 +22,6 @@ export const RxBuilder = <T, S extends Cases<T>>({
   effects,
   sources = [],
   debug = false,
-  storeValue = false,
   ...sliceConfig
 }: RxConfig<T, S>) => {
   const { reducer, actions } = createSlice(sliceConfig);
@@ -68,9 +68,9 @@ export const RxBuilder = <T, S extends Cases<T>>({
     ]),
   ) as { [K in keyof S]: (payload: unknown) => void };
 
-  return [
-    hub.store({ reducer, debug, storeValue, name: sliceConfig.name }),
+  return storeValue([
+    hub.store({ reducer, debug, name: sliceConfig.name }),
     actionsResult,
     hub.messages$,
-  ] as Reactable<T, { [K in keyof S]: (payload?: unknown) => void }>;
+  ]) as Reactable<T, { [K in keyof S]: (payload?: unknown) => void } & DestroyAction>;
 };


### PR DESCRIPTION
# Description

Makes every reactable store its value with `ReplaySubject`. Update relevant factories and `combine` helper to ensure `destroy` method always available for teardown.

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
