### PR TITLE
[154] remove Array.at for better browser support

### DIFF
--- a/packages/forms/src/Reducers/Hub1/removeControl.ts
+++ b/packages/forms/src/Reducers/Hub1/removeControl.ts
@@ -51,7 +51,7 @@ export const removeControl = <T>(
       // May need to reindex array items of removed control
       // if it was part of a Form Array.
       if (parentIsFormArray) {
-        const oldIndex = control.controlRef.at(parentRef.length) as number;
+        const oldIndex = control.controlRef[parentRef.length] as number;
 
         if (
           // If control is descendant.
@@ -59,7 +59,7 @@ export const removeControl = <T>(
           control.controlRef.length > parentRef.length &&
           // If the array item index was greater than the index of item removed
           // we need to decrement its index by 1.
-          oldIndex > (controlRef.at(-1) as number)
+          oldIndex > (controlRef[controlRef.length - 1] as number)
         ) {
           const newRef: ControlRef = parentRef
             .concat(oldIndex - 1)
@@ -103,7 +103,7 @@ export const removeControl = <T>(
   // Check for reindexing for changed controls
   if (parentIsFormArray) {
     _changedControls = Object.entries(_changedControls).reduce((acc, [key, control]) => {
-      const oldIndex = control.controlRef.at(parentRef.length) as number;
+      const oldIndex = control.controlRef[parentRef.length] as number;
 
       if (
         // If control is descendant.
@@ -111,7 +111,7 @@ export const removeControl = <T>(
         control.controlRef.length > parentRef.length &&
         // If the array item index was greater than the index of item removed
         // we need to decrement its index by 1.
-        oldIndex > (controlRef.at(-1) as number)
+        oldIndex > (controlRef[controlRef.length - 1] as number)
       ) {
         const newRef: ControlRef = parentRef
           .concat(oldIndex - 1)

--- a/packages/forms/src/Reducers/Hub1/updateAncestorPristineValues.ts
+++ b/packages/forms/src/Reducers/Hub1/updateAncestorPristineValues.ts
@@ -26,14 +26,18 @@ export const updateAncestorPristineValues = <T>(
     if (Array.isArray(form[parentKey].value)) {
       newValue = siblingControls
         .slice()
-        .sort((a, b) => (a.controlRef.at(-1) as number) - (b.controlRef.at(-1) as number))
+        .sort(
+          (a, b) =>
+            (a.controlRef[a.controlRef.length - 1] as number) -
+            (b.controlRef[b.controlRef.length - 1] as number),
+        )
         .map((control) => control.pristineValue);
     } else {
       // If parent is a Form Group
       newValue = siblingControls.reduce((acc, { controlRef, pristineValue }) => {
         return {
           ...acc,
-          [controlRef.at(-1) as string | number]: pristineValue,
+          [controlRef[controlRef.length - 1]]: pristineValue,
         };
       }, {});
     }

--- a/packages/forms/src/Reducers/Hub1/updateValues.ts
+++ b/packages/forms/src/Reducers/Hub1/updateValues.ts
@@ -36,7 +36,7 @@ const updateDescendantValues = <T>(
   const result = descendants.reduce((acc: BaseForm<T>, [key, control]) => {
     if (isChildRef(control.controlRef, controlRef)) {
       const newChildValue = (value as { [key: string]: any })[
-        control.controlRef.at(-1) as string
+        control.controlRef[control.controlRef.length - 1] as string
       ] as unknown;
       const validatorErrors: FormErrors = getErrors(control, newChildValue, providers);
       const oldChildValue = control.value;


### PR DESCRIPTION
# Description

Older browsers don't support Array.at. Remove this implementation for simple index reference instead


# How Has This Been Tested?

Ran unit tests

# Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
